### PR TITLE
fix: Capitalize rpc and messages to conform buf lint and fix `service.go` visibility

### DIFF
--- a/templates/proto/service.proto.tmpl
+++ b/templates/proto/service.proto.tmpl
@@ -27,16 +27,17 @@ service {{.Package | PascalCase}}Service {
     {{- range .Services}}
     {{range .CustomProtoComments}}// {{ .}}
     {{end -}}
-    rpc {{.Name}}({{.Name}}Request) returns ({{.Name}}Response) {
+    {{with $ucName := .Name | UpperFirstCharacter}}
+    rpc {{$ucName}}({{$ucName}}Request) returns ({{$ucName}}Response) {
         {{range .HttpOptions}}{{ .}}
         {{end}}
-    }{{end}}
+    }{{end}}{{end}}
 }
 
 {{range $key, $value := .Messages}}
 {{range $value.CustomProtoComments}}// {{ .}}
 {{end -}}
-message {{$value.ProtoName}} {
+message {{$value.ProtoName | UpperFirstCharacter}} {
 {{range $value.CustomProtoOptions}}{{ .}}
 {{end -}}
 {{$value.ProtoAttributes -}}

--- a/templates/proto/service.proto.tmpl
+++ b/templates/proto/service.proto.tmpl
@@ -27,7 +27,7 @@ service {{.Package | PascalCase}}Service {
     {{- range .Services}}
     {{range .CustomProtoComments}}// {{ .}}
     {{end -}}
-    {{with $ucName := .Name | UpperFirstCharacter}}
+    {{with $ucName := .Name | PascalCase}}
     rpc {{$ucName}}({{$ucName}}Request) returns ({{$ucName}}Response) {
         {{range .HttpOptions}}{{ .}}
         {{end}}
@@ -37,7 +37,7 @@ service {{.Package | PascalCase}}Service {
 {{range $key, $value := .Messages}}
 {{range $value.CustomProtoComments}}// {{ .}}
 {{end -}}
-message {{$value.ProtoName | UpperFirstCharacter}} {
+message {{$value.ProtoName | PascalCase}} {
 {{range $value.CustomProtoOptions}}{{ .}}
 {{end -}}
 {{$value.ProtoAttributes -}}

--- a/templates/service.go.tmpl
+++ b/templates/service.go.tmpl
@@ -29,7 +29,7 @@ type Service struct {
 
 {{$emitDbArgument := .EmitDbArgument}}
 {{ range .Services }}
-func (s *Service) {{.Name}}(ctx context.Context, req *pb.{{.Name}}Request) (*pb.{{.Name}}Response, error) {
+func (s *Service) {{.Name | PascalCase}}(ctx context.Context, req *pb.{{.Name | PascalCase}}Request) (*pb.{{.Name | PascalCase}}Response, error) {
 	{{ range . | Input}}{{ .}}
 	{{end}}
 	{{if not .EmptyOutput}}result, {{end}}err := s.querier.{{ .Name}}(ctx{{if $emitDbArgument}}, s.db{{end}}{{ .ParamsCallDatabase}})
@@ -41,7 +41,7 @@ func (s *Service) {{.Name}}(ctx context.Context, req *pb.{{.Name}}Request) (*pb.
 	{{end -}}
 }
 {{ end }}
-{{if not .EmitInterface}}{{if not .EmitDbArgument}}
+{{if not .EmitInterface}}{{if not $emitDbArgument}}
 func (s *Service) WithTx(tx {{if eq .SqlPackage "pgx/v5"}}pgx.Tx{{else}}*sql.Tx{{end}}) *Service {
 	return &Service{
 		querier: s.querier.WithTx(tx),

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -12,9 +12,8 @@ import (
 var Files embed.FS
 
 var Funcs = template.FuncMap{
-	"PascalCase":          converter.ToPascalCase,
-	"SnakeCase":           converter.ToSnakeCase,
-	"UpperFirstCharacter": converter.UpperFirstCharacter,
-	"Input":               metadata.InputGrpc,
-	"Output":              metadata.OutputGrpc,
+	"PascalCase": converter.ToPascalCase,
+	"SnakeCase":  converter.ToSnakeCase,
+	"Input":      metadata.InputGrpc,
+	"Output":     metadata.OutputGrpc,
 }

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -12,8 +12,9 @@ import (
 var Files embed.FS
 
 var Funcs = template.FuncMap{
-	"PascalCase": converter.ToPascalCase,
-	"SnakeCase":  converter.ToSnakeCase,
-	"Input":      metadata.InputGrpc,
-	"Output":     metadata.OutputGrpc,
+	"PascalCase":          converter.ToPascalCase,
+	"SnakeCase":           converter.ToSnakeCase,
+	"UpperFirstCharacter": converter.UpperFirstCharacter,
+	"Input":               metadata.InputGrpc,
+	"Output":              metadata.OutputGrpc,
 }


### PR DESCRIPTION
To reproduce the bug, you may create the `queries.sql` that contains lowercase names, that breaks generated sources by inheriting that lowercase names as struct names and methods names, which lead to generating non-exported methods and entities in the API.